### PR TITLE
Revert "Bump @react-navigation/drawer from 5.8.6 to 5.9.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2582,9 +2582,9 @@
       }
     },
     "@react-navigation/drawer": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-5.9.0.tgz",
-      "integrity": "sha512-YcuJ9QD4cFyjfXJx6vMsG3u3bfOU/Nt+GvMMl+4rZOxw2LStmubY1jqfsEAli/+dTUHv5kXJf5dF+/GhUCqA5g==",
+      "version": "5.8.6",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-5.8.6.tgz",
+      "integrity": "sha512-MuD/aIHQ3dNxB9dDzuW5B7X9e3o26I9bsjO0IB3I4MtwaQ3M4QqpBPCwWv3u35SQ7JMztnkc/bZ6WYRm5yrF4Q==",
       "requires": {
         "color": "^3.1.2",
         "react-native-iphone-x-helper": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-ios": "bundle exec fastlane build_ios"
   },
   "dependencies": {
-    "@react-navigation/drawer": "^5.9.0",
+    "@react-navigation/drawer": "^5.8.6",
     "@react-navigation/native": "^5.7.1",
     "react": "^16.13.1",
     "react-native": "^0.63.2",


### PR DESCRIPTION
This reverts commit 523b8b018ce40e54e83b920f266c38d79b904dd4.