### PR TITLE
Remove test attributes from resolution text for correct displaying

### DIFF
--- a/src/screens/ImageScreen.js
+++ b/src/screens/ImageScreen.js
@@ -51,10 +51,7 @@ class ImageScreen extends Component {
         <SafeAreaView flex={1}>
           <View style={globalStyles.centredView}>
             {data && (
-              <Text
-                h2
-                testID="image-info-testID"
-                accessibilityLabel="image-info-accessibilityLabel">
+              <Text h2>
                 {data.width}x{data.height}
               </Text>
             )}


### PR DESCRIPTION
XCUIElementTypeStaticText element on iOS displays accessibilityLabel value (image-info-accessibilityLabel) instead of real text displayed on the screen